### PR TITLE
Return null/undefined verbatim from preventDefault.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 function preventDefault(obj) {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
   function handleEvent(e) {
     if(isPreventDefaultAvailable(e) && isPreventDefaultAFunction(e)) {
       e.preventDefault();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prevent-default-wrapper",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnnynotsolucky/prevent-default-wrapper.git"
+    "url": "git+https://github.com/p/prevent-default-wrapper.git"
   },
   "author": "johnnynotsolucky",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/johnnynotsolucky/prevent-default-wrapper/issues"
+    "url": "https://github.com/p/prevent-default-wrapper/issues"
   },
-  "homepage": "https://github.com/johnnynotsolucky/prevent-default-wrapper#readme",
+  "homepage": "https://github.com/p/prevent-default-wrapper#readme",
   "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/johnnynotsolucky/prevent-default-wrapper#readme",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^2.5.3",
-    "sinon": "^1.17.4"
+    "chai": "^4.1.2",
+    "mocha": "^5.0.0",
+    "sinon": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prevent-default-wrapper",
+  "name": "@rq/prevent-default-wrapper",
   "version": "0.0.4",
   "description": "",
   "main": "index.js",

--- a/test/index.specs.js
+++ b/test/index.specs.js
@@ -8,7 +8,7 @@ describe('preventDefault Wrapper', function() {
   };
 
   afterEach(function() {
-    mockEvent.preventDefault.reset();
+    mockEvent.preventDefault.resetHistory();
   });
 
   it('calls preventDefault if an event object is passed through', function() {

--- a/test/index.specs.js
+++ b/test/index.specs.js
@@ -15,10 +15,10 @@ describe('preventDefault Wrapper', function() {
     assert.equal(preventDefault(mockEvent), true);
     assert.equal(mockEvent.preventDefault.calledOnce, true);
   });
-  
+
   it('calls preventDefault when an event handler is called', function () {
-    var mockHandler = function(e) { 
-      return 1; 
+    var mockHandler = function(e) {
+      return 1;
     };
     var fn = preventDefault(mockHandler);
     assert.equal(typeof fn, 'function');
@@ -26,8 +26,16 @@ describe('preventDefault Wrapper', function() {
     assert.equal(mockEvent.preventDefault.calledOnce, true);
   });
 
+  it('returns null if null is passed', function() {
+    assert.equal(preventDefault(null), null);
+  });
+
+  it('returns undefined if undefined is passed', function() {
+    assert.equal(preventDefault(undefined), undefined);
+  });
+
   it('returns false if neither an event or a function is passed', function() {
-    assert.equal(preventDefault(), false);
+    assert.equal(preventDefault(2), false);
     assert.equal(preventDefault({}), false);
   });
 


### PR DESCRIPTION
Thanks for this handy utility!

When using React, a common pattern is:

<pre>
  onClick={preventDefault(this.props.onClick)}
</pre>

When onClick is not passed in props, this yields the
following React warning:

<pre>
Warning: Expected `onClick` listener to be a function, instead got `false`.
</pre>

Pass through null and undefined values to handle this case.